### PR TITLE
Tweak default and bold font borders and outlines for readability

### DIFF
--- a/bold.cfg
+++ b/bold.cfg
@@ -1,8 +1,8 @@
 // Play-Bold.ttf bold 8 0.3:0.4:0.45:0.55 5 5 0.75:2.5 1.25 30 30 512 512 20 40 64 fonts/
 font "bold" "<grey>fonts/bold0.png" 20 40
 fontscale 64
-fontborder 0.3 0.4
-fontoutline 0.45 0.55
+fontborder 0.25 0.45
+fontoutline 0.35 0.55
 fontoffset "À"
 fontchar 144 120 29 33 -3.25 1.875 22 // À (1 -> 0xC0)
 fontchar 110 120 29 33 -3.25 1.625 22 // Á (2 -> 0xC1)

--- a/default.cfg
+++ b/default.cfg
@@ -1,8 +1,8 @@
 // data/fonts/Play-Regular.ttf default 8 0.3:0.4:0.45:0.55 5 5 0.75:2.5 1.25 30 30 512 512 20 40 64 fonts/
 font "default" "<grey>fonts/play0.png" 20 40
 fontscale 48
-fontborder 0.3 0.4
-fontoutline 0.4 0.5
+fontborder 0.25 0.45
+fontoutline 0.35 0.55
 fontoffset "À"
 fontchar 455 41 27 33 -2.75 1.375 21.5 // À (1 -> 0xC0)
 fontchar 423 41 27 33 -2.75 1.125 21.5 // Á (2 -> 0xC1)


### PR DESCRIPTION
Given the use of one-dimensional SDF fonts (instead of MSDF fonts), we need to use relatively wide border/outline sizes to ensure good readability at small sizes. Otherwise, fonts become pixelated.

Fonts will look a bit less sharp as a result, but I feel this is better than having overly crisp fonts (which can harm readability).

The benefit is mainly visible at 1080p, but it's also noticeable at 1440p – see the screenshots below.

## Preview

*Click to view at full size.*

### Before

![20211228230623](https://user-images.githubusercontent.com/180032/147610735-bb3c164b-f307-4011-81eb-4d57ec040d47.png)

### After

![20211228230508](https://user-images.githubusercontent.com/180032/147610727-bbda1b92-c81d-4179-8e6d-1bade7ee3c9f.png)